### PR TITLE
fix strong mode issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .buildlog
 .DS_Store
 .idea
+.packages
 .project
 .pub/
 .settings/

--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -614,7 +614,8 @@ class ResumableMediaUploader {
    */
   Future _uploadChunk(Uri uri, ResumableChunk chunk, {bool lastChunk: false}) {
     // If [uploadMedia.length] is null, we do not know the length.
-    var mediaTotalLength = _uploadMedia.length;
+    var mediaTotalLength = _uploadMedia.length == null ?
+        null : _uploadMedia.length.toString();
     if (mediaTotalLength == null || lastChunk) {
       if (lastChunk) {
         mediaTotalLength = '${chunk.endOfChunk}';

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -238,7 +238,7 @@ class ApiRequestErrorDetail {
       this.location,
       this.locationType,
       this.extendedHelp,
-      this.sendReport});
+      this.sendReport}) : originalJson = null;
 
   ApiRequestErrorDetail.fromJson(core.Map json) :
       originalJson = json,


### PR DESCRIPTION
Fix some issues caught by strong mode:

```
A value of type 'String' cannot be assigned to a variable of type 'int' (package:_discoveryapis_commons/src/clients.dart, line 620, col 28)
Type check failed: '${chunk.endOfChunk}' (String) is not of type int (package:_discoveryapis_commons/src/clients.dart, line 620, col 28)
A value of type 'String' cannot be assigned to a variable of type 'int' (package:_discoveryapis_commons/src/clients.dart, line 622, col 28)
Type check failed: '*' (String) is not of type int (package:_discoveryapis_commons/src/clients.dart, line 622, col 28)
The final variable 'originalJson' must be initialized (package:_discoveryapis_commons/src/requests.dart, line 234, col 3)
```

One uninitialized final var, and one field used as both an `int` and a `String`.
