### PR TITLE
Fix range check.

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -155,7 +155,7 @@ class ByteRange {
   core.int get length => end - start + 1;
 
   ByteRange(this.start, this.end) {
-    if (!(start == 0 && end == -1 || start >= 0 && end > start)) {
+    if (!(start == 0 && end == -1 || start >= 0 && end >= start)) {
       throw new core.ArgumentError('Invalid media range [$start, $end]');
     }
   }

--- a/test/discoveryapis_commons_test.dart
+++ b/test/discoveryapis_commons_test.dart
@@ -263,7 +263,9 @@ main() {
       expect(fullRange.start, equals(0));
       expect(fullRange.end, equals(-1));
 
-      expect(() => new ByteRange(0, 0), throwsA(anything));
+      var singleByte = new ByteRange(0, 0);
+      expect(singleByte.length, equals(1));
+
       expect(() => new ByteRange(-1, 0), throwsA(anything));
       expect(() => new ByteRange(-1, 1), throwsA(anything));
 


### PR DESCRIPTION
Start and end are both inclusive in ByteRange, so it should be possible
to create a range of 0-0.

Fixes #6.