### PR TITLE
Allow string error codes in error responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: dart
 
 dart:
   - dev
+  - stable
 
 dart_task:
   - test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.8
+
+- Support Dart 2.
+- Allow response errors with non-integer error codes.
+
 ## 0.1.6+1
 
 - Require Dart 2.0.0-dev.64

--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -856,8 +856,20 @@ Future<http.StreamedResponse> _validateResponse(
       var jsonResponse = await stringStream.transform(json.decoder).first;
       if (jsonResponse is Map && jsonResponse['error'] is Map) {
         final Map error = jsonResponse['error'];
-        final code = error['code'] as int;
+        final codeValue = error['code'];
         final message = error['message'] as String;
+
+        int code;
+        if (codeValue is String) {
+          code = int.tryParse(codeValue) ?? 0;
+          if (code == null) {
+            // This can happen on some non-google services.
+            throw new client_requests.ApiRequestError(message);
+          }
+        } else {
+          code = codeValue as int;
+        }
+
         var errors = <client_requests.ApiRequestErrorDetail>[];
         if (error.containsKey('errors') && error['errors'] is List) {
           errors = (error['errors'] as List)

--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -870,7 +870,7 @@ Future<http.StreamedResponse> _validateResponse(
               .toList();
         }
         throw client_requests.DetailedApiRequestError(code, message,
-            errors: errors, jsonResponse: jsonResponse as Map<String, Object>);
+            errors: errors, jsonResponse: jsonResponse as Map<String, dynamic>);
       }
     }
     throw client_requests.DetailedApiRequestError(

--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -859,16 +859,8 @@ Future<http.StreamedResponse> _validateResponse(
         final codeValue = error['code'];
         final message = error['message'] as String;
 
-        int code;
-        if (codeValue is String) {
-          code = int.tryParse(codeValue) ?? 0;
-          if (code == null) {
-            // This can happen on some non-google services.
-            throw new client_requests.ApiRequestError(message);
-          }
-        } else {
-          code = codeValue as int;
-        }
+        final code =
+            codeValue is String ? int.tryParse(codeValue) : codeValue as int;
 
         var errors = <client_requests.ApiRequestErrorDetail>[];
         if (error.containsKey('errors') && error['errors'] is List) {
@@ -878,7 +870,7 @@ Future<http.StreamedResponse> _validateResponse(
               .toList();
         }
         throw client_requests.DetailedApiRequestError(code, message,
-            errors: errors);
+            errors: errors, jsonResponse: jsonResponse as Map<String, Object>);
       }
     }
     throw client_requests.DetailedApiRequestError(

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -176,12 +176,16 @@ class ApiRequestError extends core.Error {
  * Represents a specific error reported by the API endpoint.
  */
 class DetailedApiRequestError extends ApiRequestError {
+  /// The error code. For some non-google services this can be `null`.
   final core.int status;
 
   final core.List<ApiRequestErrorDetail> errors;
 
+  /// The full error response as decoded json if available. `null` otherwise.
+  final core.Map<core.String, core.dynamic> jsonResponse;
+
   DetailedApiRequestError(this.status, core.String message,
-      {this.errors = const []})
+      {this.errors = const [], this.jsonResponse})
       : super(message);
 
   core.String toString() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: _discoveryapis_commons
-version: 0.1.7-dev
+version: 0.1.8
 author: Dart Team <misc@dartlang.org>
 description: Library for use by client APIs generated from Discovery Documents.
 homepage: https://github.com/dart-lang/discoveryapis_commons
 environment:
-  sdk: '>=2.0.0-dev.64.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 dependencies:
   http: '>=0.11.1 <0.12.0'
 dev_dependencies:
-  test: ^1.2.0
+  test: ^1.3.0


### PR DESCRIPTION
Also update pubspec to dart 2.
This fixes: https://github.com/dart-lang/discoveryapis_commons/issues/22