### PR TITLE
Fix responses where the content-length isn't given

### DIFF
--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -93,7 +93,10 @@ class ApiRequester {
           "No 'content-type' header in media response.");
     }
 
-    var contentLength = int.tryParse(response.headers['content-length']);
+    int contentLength;
+    if (response.headers['content-length'] != null) {
+      contentLength = int.tryParse(response.headers['content-length']);
+    }
 
     if (downloadRange != null) {
       if (contentLength != downloadRange.length) {


### PR DESCRIPTION
In a recent commit (@kevmoo 9802222b452f176190b0d16c03488a7c76f85348) this code was broken.

The function used to ignore cases when no content-length was given. In the current version, the library now throws, since `int.tryParse` throws when the given argument is `null`.