### PR TITLE
Broaden dependency range of http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://github.com/dart-lang/discoveryapis_commons
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.1 <0.13.0'
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
This was needed in conjunction with the current flutter version.
```
Because every version of flutter_test from sdk depends on http 0.12.0 and _discoveryapis_commons >=0.1.6+1 depends on http ^0.11.1, flutter_test from sdk is incompatible with _discoveryapis_commons >=0.1.6+1.
And because _discoveryapis_commons <=0.1.6 requires SDK version >=1.0.0 <2.0.0 or >=2.0.0-dev.20.0 <2.0.0, flutter_test from sdk is incompatible with _discoveryapis_commons.
So, because exitlive_mobile depends on both _discoveryapis_commons any and flutter_test any from sdk, version solving failed.
```