### PR TITLE
Send client library identifier

### DIFF
--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'requests.dart' as client_requests;
+import 'version_fallback.dart' if (dart.library.io) 'version_io.dart';
 
 const CONTENT_TYPE_JSON_UTF8 = 'application/json; charset=utf-8';
 
@@ -206,12 +207,14 @@ class ApiRequester {
           'content-type': CONTENT_TYPE_JSON_UTF8,
           'content-length': '$length',
           'range': 'bytes=${downloadRange.start}-${downloadRange.end}',
+          'x-goog-api-client': 'gl-dart/$dartVersion',
         };
       } else {
         headers = {
           'user-agent': _userAgent,
           'content-type': CONTENT_TYPE_JSON_UTF8,
           'content-length': '$length',
+          'x-goog-api-client': 'gl-dart/$dartVersion',
         };
       }
       // Filter out headers forbidden in the browser (in calling in browser).

--- a/lib/src/version_fallback.dart
+++ b/lib/src/version_fallback.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Hardcoded dart version as `Platform` from `dart:io` is not available when
+/// targeting javascript.
+final dartVersion = '2.0.0';

--- a/lib/src/version_io.dart
+++ b/lib/src/version_io.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io' show Platform;
+
+/// Major.minor.patch version of current dart version.
+final dartVersion = Platform.version.split(RegExp('[^0-9]')).take(3).join('.');


### PR DESCRIPTION
Afaik I heard @sortie was working on moving `Platform` out of `dart:io`, but for now I guess we'll have to fall back to conditional imports.