### PR TITLE
Publish a final v2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.1
+
+- Removed a `library` directive causing the API docs to be hidden.
+- Fixed a number of documentation comment issues.
+- Now requires Dart `2.10.0`.
+- Allow the latest `package:http`.
+
 ## 0.2.0
 
  - Changed `ApiRequestError` (and its subclass `DetailedApiRequestError`) from

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,10 +4,10 @@ analyzer:
     implicit-casts: false
   errors:
     dead_code: error
-    override_on_non_overriding_method: error
     unused_element: error
     unused_import: error
     unused_local_variable: error
+
 linter:
   rules:
     - always_declare_return_types
@@ -25,6 +25,7 @@ linter:
     - await_only_futures
     - camel_case_types
     - cancel_subscriptions
+    - comment_references
     - control_flow_in_finally
     - directives_ordering
     - empty_catches

--- a/lib/_discoveryapis_commons.dart
+++ b/lib/_discoveryapis_commons.dart
@@ -2,7 +2,5 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library _discoveryapis_commons;
-
 export 'src/clients.dart' show ApiRequester, Escaper, mapMap;
 export 'src/requests.dart';

--- a/lib/src/clients.dart
+++ b/lib/src/clients.dart
@@ -38,14 +38,14 @@ class ApiRequester {
   }
 
   /// Sends a HTTPRequest using [method] (usually GET or POST) to [requestUrl]
-  /// using the specified [urlParams] and [queryParams]. Optionally include a
+  /// using the specified [queryParams]. Optionally include a
   /// [body] and/or [uploadMedia] in the request.
   ///
   /// If [uploadMedia] was specified [downloadOptions] must be
-  /// [DownloadOptions.Metadata] or `null`.
+  /// [client_requests.DownloadOptions.Metadata] or `null`.
   ///
-  /// If [downloadOptions] is [DownloadOptions.Metadata] the result will be
-  /// decoded as JSON.
+  /// If [downloadOptions] is [client_requests.DownloadOptions.Metadata] the
+  /// result will be decoded as JSON.
   ///
   /// If [downloadOptions] is `null` the result will be a Future completing with
   /// `null`.
@@ -589,10 +589,7 @@ class ResumableMediaUploader {
     return tryUpload(_options.numberOfAttempts - 1);
   }
 
-  /// Uploads [length] bytes in [byteArrays] and ensures the upload was
-  /// successful.
-  ///
-  /// Content-Range: [start ... (start + length)[
+  /// Uploads [chunk] and ensures the upload was successful.
   ///
   /// Returns the returned [http.StreamedResponse] or completes with an error if
   /// the upload did not succeed. The response stream will not be listened to.

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -166,8 +166,9 @@ class DetailedApiRequestError extends ApiRequestError {
       'DetailedApiRequestError(status: $status, message: $message)';
 }
 
-/// Instances of this class can be added to an [RpcError] to provide detailed
-/// information.
+/// Instances of this class can be added to a [DetailedApiRequestError] to
+/// provide detailed information.
+///
 /// They will be sent back to the client in the `errors` field.
 ///
 /// This follows the Google JSON style guide:
@@ -178,8 +179,9 @@ class ApiRequestErrorDetail {
   /// calendar) from general protocol errors (i.e. file not found).
   final core.String domain;
 
-  /// Unique identifier for this error. Different from the [RpcError.statusCode]
-  /// property in that this is not an http response code.
+  /// Unique identifier for this error. Different from the
+  /// [DetailedApiRequestError.status] property in that this is not an http
+  /// response code.
   final core.String reason;
 
   /// A human readable message providing more details about the error. If there

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,13 @@
 name: _discoveryapis_commons
-version: 0.2.0
-author: Dart Team <misc@dartlang.org>
+version: 0.2.1
 description: Library for use by client APIs generated from Discovery Documents.
-homepage: https://github.com/dart-lang/discoveryapis_commons
+repository: https://github.com/dart-lang/googleapis
+
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
+
 dependencies:
-  http: '>=0.11.1 <0.13.0'
+  http: '>=0.11.1 <0.14.0'
+
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
- Removed a `library` directive causing the API docs to be hidden.
- Fixed a number of documentation comment issues.
- Now requires Dart `2.10.0`.
- Allow the latest `package:http`.
